### PR TITLE
Allow rejected promises to be passed as well

### DIFF
--- a/addon/adapters/adapter.js
+++ b/addon/adapters/adapter.js
@@ -24,6 +24,9 @@ export default DS.JSONAPIAdapter.extend({
     if (adapterOptions && adapterOptions.relationshipToUpdate) {
       return promise.then(() => {
         return null;
+      })
+      .catch((error) => {
+        throw error;
       });
     }
     return promise;


### PR DESCRIPTION
When using RSVP.all or RSVP.hash if this is used in a group where another promise has failed. It still needs to throw the error, otherwise you'll get an Ember.Error uncaught.